### PR TITLE
remove clicklayer directly on play event listener

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "3.0.3",
+ "version": "3.0.4",
  "name": "@stroeer/stroeer-videoplayer-ima-plugin",
  "description": "Ströer Videoplayer IMA Plugin",
  "main": "dist/stroeervideoplayer-ima-plugin.umd.js",


### PR DESCRIPTION
https://esc-1.sb.familie.de/schwangerschaft/vornamen/alte-vornamen/

When the metatag was blocked by an adblocker, the clicklayer was not removed and the controls could not be used.
we checked and it is ok, when we remove the clicklayer directly on the play event listener, because we do not need it anymore after it in all cases.