### PR TITLE
start the content video on click too for user interaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "3.0.4",
+ "version": "3.0.5",
  "name": "@stroeer/stroeer-videoplayer-ima-plugin",
  "description": "Ströer Videoplayer IMA Plugin",
  "main": "dist/stroeervideoplayer-ima-plugin.umd.js",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -46,7 +46,6 @@ class Plugin {
   adsLoader: any
   adsDisplayContainer: any
   clickLayer: HTMLDivElement
-  clickLayerClicked: boolean
   adsInitialized: boolean
 
   constructor () {
@@ -73,7 +72,6 @@ class Plugin {
     this.volume = 0
     this.loadIMAScript = new Promise((resolve, reject) => {})
     this.autoplay = false
-    this.clickLayerClicked = false
 
     this.adsManager = null
     this.adsLoader = null
@@ -117,9 +115,7 @@ class Plugin {
 
       return
     }
-    if (event.target && event.target === document.querySelector('.ima-click-layer')) {
-      this.clickLayerClicked = true
-    }
+
     // no new play event until content video is ended
     this.videoElement.removeEventListener('play', this.onVideoElementPlay)
 
@@ -696,7 +692,11 @@ class Plugin {
     // add ClickLayer
     this.clickLayer.className = 'ima-click-layer'
     videoElement.after(this.clickLayer)
-    this.clickLayer.addEventListener('click', this.onVideoElementPlay)
+    this.clickLayer.addEventListener('click', (event: Event) => {
+      videoElement.play()
+      videoElement.pause()
+      this.onVideoElementPlay(event)
+    })
   }
 
   showLoadingSpinner = (modus: boolean): void => {
@@ -727,9 +727,8 @@ class Plugin {
   }
 
   removeClickLayer = (): void => {
-    if (this.clickLayer && document.querySelector('.ima-click-layer')) {
-      this.clickLayer.parentNode?.removeChild(this.clickLayer)
-      this.clickLayerClicked = false
+    if (document.querySelector('.ima-click-layer')) {
+      this.clickLayer?.parentNode?.removeChild(this.clickLayer)
     }
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -693,6 +693,7 @@ class Plugin {
     this.clickLayer.className = 'ima-click-layer'
     videoElement.after(this.clickLayer)
     this.clickLayer.addEventListener('click', (event: Event) => {
+      // user interaction triggers also the content video for playing later
       videoElement.play()
       videoElement.pause()
       this.onVideoElementPlay(event)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -120,9 +120,8 @@ class Plugin {
     this.videoElement.removeEventListener('play', this.onVideoElementPlay)
 
     this.showLoadingSpinner(true)
-    this.videoElement.pause()
 
-    // set muted when xontent video was muted, e.g. when autoplay
+    // set muted when content video was muted, e.g. autoplay
     if (this.videoElement.muted) {
       this.isMuted = true
     }


### PR DESCRIPTION
For iOS we still had the problem, that after the ima ad was played the content video stayed paused and did not continue. It was necessary to use the user interaction (click to play) for both: ima and video. 

fixes: https://github.com/stroeer/video/issues/20

Sandbox: https://esc-1.sb.familie.de/schwangerschaft/vornamen/alte-vornamen/